### PR TITLE
6) Add heartbeat mechanism for stomp client

### DIFF
--- a/SwiftStomp/Classes/Enumurations/StompResponseFrame.swift
+++ b/SwiftStomp/Classes/Enumurations/StompResponseFrame.swift
@@ -12,4 +12,5 @@ public enum StompResponseFrame: String {
     case message = "MESSAGE"
     case receipt = "RECEIPT"
     case error = "ERROR"
+    case serverPing = "SERVER_PING"
 }

--- a/SwiftStomp/Classes/FrameHelpers/StompFrame.swift
+++ b/SwiftStomp/Classes/FrameHelpers/StompFrame.swift
@@ -82,7 +82,7 @@ struct StompFrame<T: RawRepresentable> where T.RawValue == String {
         }
         
         // End with NULL terminator
-        frame += NULL_CHAR
+        frame += StompConstants.nullChar
         
         return frame
     }
@@ -91,6 +91,13 @@ struct StompFrame<T: RawRepresentable> where T.RawValue == String {
     /// - Parameter frame: A full STOMP string with command, headers, and body
     /// - Throws: If parsing the frame fails
     mutating func deserialize(frame: String) throws {
+        // If the frame consists of only a single newline character "\n", interpret it as a Heartbeat from the server
+        if frame == StompConstants.heartbeatSymbol {
+            name = (StompResponseFrame.serverPing as! T)
+            body = frame
+            return
+        }
+        
         var lines = frame.components(separatedBy: "\n")
         
         // ** Remove first if was empty string

--- a/SwiftStomp/Classes/SwiftStomp.swift
+++ b/SwiftStomp/Classes/SwiftStomp.swift
@@ -56,9 +56,9 @@ public class SwiftStomp: NSObject {
     /// The WebSocket endpoint (STOMP broker URL)
     fileprivate var host: URL
     /// HTTP headers to include during the initial WebSocket handshake
-    fileprivate var httpConnectionHeaders: [String: String]?
+    fileprivate var httpConnectionHeaders: [String: String]
     /// STOMP-specific headers used during the STOMP CONNECT frame
-    fileprivate var stompConnectionHeaders: [String: String]?
+    fileprivate var stompConnectionHeaders: [String: String]
 
     /// WebSocket infrastructure using URLSession
     fileprivate var urlSession: URLSession?
@@ -153,7 +153,7 @@ public class SwiftStomp: NSObject {
     public var autoReconnect = false
 
     /// Creates a new STOMP client with the given host and optional headers
-    public init (host: URL, headers: [String: String]? = nil, httpConnectionHeaders: [String: String]? = nil, proxyMode: ProxyMode? = nil) {
+    public init (host: URL, headers: [String: String] = [:], httpConnectionHeaders: [String: String] = [:], proxyMode: ProxyMode? = nil) {
         self.host = host
         self.stompConnectionHeaders = headers
         self.httpConnectionHeaders = httpConnectionHeaders
@@ -225,10 +225,8 @@ public extension SwiftStomp {
         //** Time interval
         urlRequest.timeoutInterval = timeout
 
-        if let httpConnectionHeaders {
-            for header in httpConnectionHeaders {
-                urlRequest.addValue(header.value, forHTTPHeaderField: header.key)
-            }
+        for header in httpConnectionHeaders {
+            urlRequest.addValue(header.value, forHTTPHeaderField: header.key)
         }
 
         self.webSocketTask = urlSession?.webSocketTask(with: urlRequest)
@@ -489,13 +487,11 @@ private extension SwiftStomp {
             .get
 
         //** Append connection headers
-        if let stompConnectionHeaders = self.stompConnectionHeaders{
-            for (hKey, hVal) in stompConnectionHeaders{
-                headers[hKey] = hVal
-            }
+        for (hKey, hVal) in stompConnectionHeaders{
+            headers[hKey] = hVal
         }
 
-        saveHeartbeatClientSettings(connectedHeaders: stompConnectionHeaders ?? [:])
+        saveHeartbeatClientSettings(connectedHeaders: stompConnectionHeaders)
 
         self.sendFrame(frame: StompFrame(name: .connect, headers: headers))
     }


### PR DESCRIPTION
Изменения, которые делал Стас в рамках RND - https://github.com/StanislavKlem/SwiftStomp/commit/0173f009a8fd15544a068bc697873eb47ec67ba1#diff-88116a01e955614cdf97766fa275f3f92f7f9a1424fb957729262426940c8479
по сути про хартбиты взято отттуда.


**Что такое хартбиты по-простому.**
Клиент SwiftStomp (то есть фронт, то есть ios) устанавливает соединение с сервером (наш бек, к примеру).
Чтобы бекенд понимал, что мы на связи, мы периодически отправляем хартбиты/пинги (по нашим договоренностям это символ переноса строки). Мы их отправляем, бекенд их получает и понимает что связь с нами жива. В свою очередь бекенд нам тоже отправляет пинги (тоже перенос строки), но мы сейчас это никак не обрабатываем и не учитываем (нет в этом необходимости на текущем этапе).


В библиотеке, есть технология авто-пингов (по сути те же самые хартбиты, можно посмотреть флаг autoPingEnabled), но не до конца понятно как их можно было бы переиспользовать, как я понимаю еще в рамках RnD в прошлом году пришли к текущем варианту.